### PR TITLE
External links open in new tab

### DIFF
--- a/quartz/quartz.config.ts
+++ b/quartz/quartz.config.ts
@@ -69,7 +69,7 @@ const config: QuartzConfig = {
       Plugin.ObsidianFlavoredMarkdown({ enableInHtmlEmbed: false }),
       Plugin.GitHubFlavoredMarkdown(),
       Plugin.TableOfContents(),
-      Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
+      Plugin.CrawlLinks({ markdownLinkResolution: "shortest", openLinksInNewTab: true }),
       Plugin.Description(),
       Plugin.CodeRunner(),
     ],

--- a/quartz/quartz.config.ts
+++ b/quartz/quartz.config.ts
@@ -69,7 +69,7 @@ const config: QuartzConfig = {
       Plugin.ObsidianFlavoredMarkdown({ enableInHtmlEmbed: false }),
       Plugin.GitHubFlavoredMarkdown(),
       Plugin.TableOfContents(),
-      Plugin.CrawlLinks({ markdownLinkResolution: "shortest", openLinksInNewTab: true }),
+      Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
       Plugin.Description(),
       Plugin.CodeRunner(),
     ],

--- a/quartz/quartz/plugins/transformers/links.ts
+++ b/quartz/quartz/plugins/transformers/links.ts
@@ -23,6 +23,9 @@ interface Options {
   openLinksInNewTab: boolean
   lazyLoad: boolean
   externalLinkIcon: boolean
+
+  /** Open all external links in a new tab, default == true */
+  openExternalLinksInNewTab: boolean
 }
 
 const defaultOptions: Options = {
@@ -31,6 +34,7 @@ const defaultOptions: Options = {
   openLinksInNewTab: false,
   lazyLoad: false,
   externalLinkIcon: true,
+  openExternalLinksInNewTab: true,
 }
 
 export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> = (userOpts) => {
@@ -93,7 +97,7 @@ export const CrawlLinks: QuartzTransformerPlugin<Partial<Options> | undefined> =
                 }
                 node.properties.className = classes
 
-                if (opts.openLinksInNewTab) {
+                if (opts.openLinksInNewTab || (isExternal && opts.openExternalLinksInNewTab)) {
                   node.properties.target = "_blank"
                 }
 


### PR DESCRIPTION
In de huidige situatie worden links naar een externe websites in hetzelfde tabblad geopend. Dit is erg onhandig als je bezig bent met het lezen en wat extra informatie wil opzoeken. Met deze aanpassing worden externe links, links met http en https geopend in een nieuw tabblad

![image](https://github.com/Windesheim-HBO-ICT/Leertaken/assets/31829786/ae7ebf63-e47e-489f-b6d8-f90f7e027fda)
[Quartz docs](https://quartz.jzhao.xyz/plugins/CrawlLinks)